### PR TITLE
Fix multiple glaring typos that exist right now

### DIFF
--- a/04 - Custom Stages.md
+++ b/04 - Custom Stages.md
@@ -159,13 +159,9 @@ The animation names the game uses by default are:
 
 When the game starts, it queries the list of possible characters by searching in the `data/characters` folder for JSON files. This gets used to preload data which is used later when the character is loaded in a stage.
 
-## Replacing/Reskinning an Existing Character
-
-As a short aside, you can create a JSON with the same filename as an existing character (from the base game, or from a mod if your mod loads after it) and it will replace it. This can be used to create more elaborate reskins for characters, such as ones that use a different render type.
-
 ## Using a Stage in a Song
 
-There are two ways to use your character in a song once it's implemented.
+There are two ways to use your stage in a song once it's implemented.
 
 1. Create a new chart. Open the Chart Editor, start a chart, and select the stage from the `Metadata` toolbox before charting.
 2. Edit an existing chart in your mod. Open the `metadata.json` file and check in `playData` for the `stage` key, and set it to your internal ID.


### PR DESCRIPTION
There are two typos that exist in the stage page that I have fixed with this PR. One is in the section where it tells you how to use it in your song, where it refers to the stage as a character. The other is another one which may be leftovers from some process you used, but it doesn't need to exist anyway. It's just the reskin section from the character page copied over to the stage page, so I just got rid of that part. I could add back the second one if you want (and if I feel like it). I'd prefer no questions asked though cuz I might not get back.