### PR TITLE
Fix a typo: Flash CS6 cannot export Animate Atlases.

### DIFF
--- a/src/03-custom-characters/03-01-character-assets.md
+++ b/src/03-custom-characters/03-01-character-assets.md
@@ -2,7 +2,7 @@
 
 The individual sprites of a character's animations must be combined into a spritesheet for the game to use them. Friday Night Funkin' supports one of several formats:
 
-- `sparrow`: Combines the images into a large sheet, then provides an XML file containing the coordinates of each frame with it. Can be exported directly from Adobe Animate using the `Generate Sprite Sheet` option, or can be created from individual frames using [Free Texture Packer](http://free-tex-packer.com/) (note that Free Texture Packer refers to this format as Starling).
+- `sparrow`: Combines the images into a large sheet, then provides an XML file containing the coordinates of each frame with it. Can be exported directly from Adobe Animate or Flash CS6 using the `Generate Sprite Sheet` option, or can be created from individual frames using [Free Texture Packer](http://free-tex-packer.com/) (note that Free Texture Packer refers to this format as Starling).
 
 - `packer`: Combines images into a sheet, then provides a TXT file containing the coordinates of each frame.
 

--- a/src/03-custom-characters/03-01-character-assets.md
+++ b/src/03-custom-characters/03-01-character-assets.md
@@ -6,6 +6,6 @@ The individual sprites of a character's animations must be combined into a sprit
 
 - `packer`: Combines images into a sheet, then provides a TXT file containing the coordinates of each frame.
 
-- `animateatlas`: Created exclusively when using Adobe Flash CS6 or Adobe Animate, this exports individual symbols into a large sheet, then provides a JSON file with data to split up each symbol, then provides a second JSON to arrange those symbols into animations. Great for performance, especially for characters which were made by rearranging smaller parts. We use the [FlxAnimate](https://github.com/Dot-Stuff/flxanimate) Haxelib for this.
+- `animateatlas`: Created exclusively when using Adobe Animate, this exports individual symbols into a large sheet, then provides a JSON file with data to split up each symbol, then provides a second JSON to arrange those symbols into animations. Great for performance, especially for characters which were made by rearranging smaller parts. We use the [FlxAnimate](https://github.com/Dot-Stuff/flxanimate) Haxelib for this.
 
 - `multisparrow`: Allows for different groups of animations to be exported into separate Sparrow spritesheets, then combined together into one character.


### PR DESCRIPTION
The docs say that Flash CS6 can export Animate Atlases. It can't. I tried. You might have been confused because it can export spritesheets. I fixed it in this. 
I also added the comment to the other sprite sheet format that indeed CAN be exported from Flash CS6.