### PR TITLE
Add Missing Fields for Character Data

### DIFF
--- a/src/03-custom-characters/03-02-creating-a-character.md
+++ b/src/03-custom-characters/03-02-creating-a-character.md
@@ -118,17 +118,17 @@ The available fields are:
 Health Icon data is structured like so:
   - `id`: The ID to use for the health icon, defaults to character's ID.
   - `scale`: Specify the size of the health icon relative to the original size. For example, `2.0` makes the sprite twice as big. Optional, defaults to `1.0`.
-  - `flipX`: Whether to flip the whole sprite horizontally in-game.
+  - `flipX`: Whether to flip the whole sprite horizontally in-game. Optional, defaults to `false`.
   - `isPixel`: Specify whether to disable texture smoothing for this characters health icon. Optional, defaults to `false`.
-  - `offsets`:
+  - `offsets`: The offset of the health icon, in pixels. Optional, defaults to `[0, 0]`.
     - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
 
 Death data is structured like so:
-  - `cameraOffsets`: The amount to offset the camera by while focusing on this character as they die.
+  - `cameraOffsets`: The amount to offset the camera by while focusing on this character as they die. Optional, defaults to `[0, 0]`.
     - Default value focuses on the character's graphic midpoint.
     - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
-  - `cameraZoom`: The amount to zoom the camera by while focusing on this character as they die.
-  - `preTransitionDelay`: The delay between when the character reaches `0` health and when the death animation plays.
+  - `cameraZoom`: The amount to zoom the camera by while focusing on this character as they die. Optional, defaults to `1`.
+  - `preTransitionDelay`: The delay between when the character reaches `0` health and when the death animation plays. Optional, defaults to `0`.
 
 Animation data is structured like so:
 - `name`: The internal animation name for the game to use.

--- a/src/03-custom-characters/03-02-creating-a-character.md
+++ b/src/03-custom-characters/03-02-creating-a-character.md
@@ -98,11 +98,39 @@ The available fields are:
   - For the `packer` asset type, this must point to the path where the `txt` and `png` are located, without the file extension.
   - For the `animateatlas` asset type, this must point to the folder where the `Animation.json` and any spritemaps are located.
   - For the `multisparrow` asset type, point to the path where your main Sparrow spritesheet is located. On each animations which uses a different Sparrow spritesheet from the main one, add the `assetPath` key to that specific animation.
+- `scale`: Specify the size of the character relative to the original size. For example, `2.0` makes the sprite twice as big. Optional, defaults to `1.0`.
+- `healthIcon`: Data for the health icon to display in-game. For example, Boyfriend will obviously use Boyfriend's health icon.
+- `death`: Data for the death screen to use, when the character reaches `0` health.
+- `offsets`: The global offset to the character's position, in pixels.
+  - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
+- `cameraOffsets`: The amount to offset the camera by while focusing on this character.
+  - Default value focuses on the character directly.
+  - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
+- `isPixel`: Specify whether to display the character as pixel (disabling texture smoothing). Optional, defaults to `false`.
+- `danceEvery`: The frequency at which the character will play its idle animation, in beats. Optional, defaults to `1`.
+  - Increasing this number will make the character dance less often.
+- `flipX`: Whether to flip the whole sprite horizontally in-game. Useful for characters that could also be played (Pico).
 - `startingAnimation`: The animation for the character to play when they are first loaded in.
 - `singTime`: The amount of time, in steps, for a character to keep singing after they let go of a note.
   - Decrease this if the character seems to hold their poses for too long after their section is done.
   - Increase this if the character resets to the idle animation in the middle of their singing animations.
 - `animations`: A list of animation data objects for the character.
+
+Health Icon data is structured like so:
+  - `id`: The ID to use for the health icon, defaults to character's ID.
+  - `scale`: Specify the size of the health icon relative to the original size. For example, `2.0` makes the sprite twice as big. Optional, defaults to `1.0`.
+  - `flipX`: Whether to flip the whole sprite horizontally in-game.
+  - `isPixel`: Specify whether to display the health icon as pixel (disabling texture smoothing). Optional, defaults to `false`.
+  - `offsets`:
+    - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
+
+Death data is structured like so:
+  - `cameraOffsets`: The amount to offset the camera by while focusing on this character as they die.
+    - Default value focuses on the character's graphic midpoint.
+    - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
+  - `cameraZoom`: The amount to zoom the camera by while focusing on this character as they die.
+  - `preTransitionDelay`: The delay between when the character reaches `0` health and when the death animation plays.
+
 
 Animation data is structured like so:
 - `name`: The internal animation name for the game to use.

--- a/src/03-custom-characters/03-02-creating-a-character.md
+++ b/src/03-custom-characters/03-02-creating-a-character.md
@@ -106,7 +106,7 @@ The available fields are:
 - `cameraOffsets`: The amount to offset the camera by while focusing on this character.
   - Default value focuses on the character directly.
   - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
-- `isPixel`: Specify whether to display the character as pixel (disabling texture smoothing). Optional, defaults to `false`.
+- `isPixel`: Specify whether to disable texture smoothing for this character. Optional, defaults to `false`.
 - `danceEvery`: The frequency at which the character will play its idle animation, in beats. Optional, defaults to `1`.
   - Increasing this number will make the character dance less often.
 - `flipX`: Whether to flip the whole sprite horizontally in-game. Useful for characters that could also be played (Pico).
@@ -120,7 +120,7 @@ Health Icon data is structured like so:
   - `id`: The ID to use for the health icon, defaults to character's ID.
   - `scale`: Specify the size of the health icon relative to the original size. For example, `2.0` makes the sprite twice as big. Optional, defaults to `1.0`.
   - `flipX`: Whether to flip the whole sprite horizontally in-game.
-  - `isPixel`: Specify whether to display the health icon as pixel (disabling texture smoothing). Optional, defaults to `false`.
+  - `isPixel`: Specify whether to disable texture smoothing for this characters health icon. Optional, defaults to `false`.
   - `offsets`:
     - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
 
@@ -130,7 +130,6 @@ Death data is structured like so:
     - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
   - `cameraZoom`: The amount to zoom the camera by while focusing on this character as they die.
   - `preTransitionDelay`: The delay between when the character reaches `0` health and when the death animation plays.
-
 
 Animation data is structured like so:
 - `name`: The internal animation name for the game to use.

--- a/src/03-custom-characters/03-02-creating-a-character.md
+++ b/src/03-custom-characters/03-02-creating-a-character.md
@@ -98,20 +98,19 @@ The available fields are:
   - For the `packer` asset type, this must point to the path where the `txt` and `png` are located, without the file extension.
   - For the `animateatlas` asset type, this must point to the folder where the `Animation.json` and any spritemaps are located.
   - For the `multisparrow` asset type, point to the path where your main Sparrow spritesheet is located. On each animations which uses a different Sparrow spritesheet from the main one, add the `assetPath` key to that specific animation.
-- `scale`: Specify the size of the character relative to the original size. For example, `2.0` makes the sprite twice as big. Optional, defaults to `1.0`.
-- `healthIcon`: Data for the health icon to display in-game. For example, Boyfriend will obviously use Boyfriend's health icon.
-- `death`: Data for the death screen to use, when the character reaches `0` health.
-- `offsets`: The global offset to the character's position, in pixels.
+- `scale` *(currently buggy)*: Specify the size of the character relative to the original size. For example, `2.0` makes the sprite twice as big. Optional, defaults to `1.0`.
+- `healthIcon`: Data for the health icon to display in-game. For example, Boyfriend will obviously use Boyfriend's health icon. Optional, defaults its ID to character's ID.
+- `death`: Data for the death screen to use, when the character reaches `0` health. Optional, doesn't default to a specific object.
+- `offsets`: The global offset to the character's position, in pixels. Optional, defaults to `[0, 0]`.
   - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
-- `cameraOffsets`: The amount to offset the camera by while focusing on this character.
-  - Default value focuses on the character directly.
+- `cameraOffsets`: The amount to offset the camera by while focusing on the character. Optional, default value focuses on the character directly.
   - Use an array of two decimal values, the first for horizontal position and the second for vertical position.
-- `isPixel`: Specify whether to disable texture smoothing for this character. Optional, defaults to `false`.
+- `isPixel`: Specify whether to disable texture smoothing for the character. Optional, defaults to `false`.
 - `danceEvery`: The frequency at which the character will play its idle animation, in beats. Optional, defaults to `1`.
   - Increasing this number will make the character dance less often.
-- `flipX`: Whether to flip the whole sprite horizontally in-game. Useful for characters that could also be played (Pico).
-- `startingAnimation`: The animation for the character to play when they are first loaded in.
-- `singTime`: The amount of time, in steps, for a character to keep singing after they let go of a note.
+- `flipX`: Whether to flip the whole sprite horizontally in-game. Useful for characters that could also be played (Pico). Optional, defaults to `false`.
+- `startingAnimation`: The animation for the character to play when they are first loaded in. Optional, defaults to `idle`.
+- `singTime`: The amount of time, in steps, for a character to keep singing after they let go of a note. Optional, defaults to `8`.
   - Decrease this if the character seems to hold their poses for too long after their section is done.
   - Increase this if the character resets to the idle animation in the middle of their singing animations.
 - `animations`: A list of animation data objects for the character.


### PR DESCRIPTION
Add missing character fields for:
* `scale`
* `healthIcon`
* `death`
* `offsets`
* `cameraOffsets`
* `isPixel`
* `danceEvery`
* `flipX`