### PR TITLE
[TYPO] Replaced `_append` with `_merge` on 10-02-merging-files.md

### DIFF
--- a/src/10-appending-and-merging-files/10-02-merging-files.md
+++ b/src/10-appending-and-merging-files/10-02-merging-files.md
@@ -97,7 +97,7 @@ Say we have a JSON data file `data/songs/mysong-metadata.json` like below:
 }
 ```
 
-We can modify the above data with a document `mods/mymod/_append/data/songs/mysong-metadata.json`:
+We can modify the above data with a document `mods/mymod/_merge/data/songs/mysong-metadata.json`:
 
 ```jsonc
 [


### PR DESCRIPTION
Fixed a typo on "10-02-merging-files.md", where the path of the JSON Patch document was "mods/mymod/**_append**/data/songs/mysong-metadata.json" instead of "mods/mymod/**_merge**/data/songs/mysong-metadata.json".