### PR TITLE
Fix "Page not found" error in 09-01-0.1.0-to-0.5.0.md

### DIFF
--- a/src/09-migration/09-01-0.1.0-to-0.5.0.md
+++ b/src/09-migration/09-01-0.1.0-to-0.5.0.md
@@ -36,7 +36,7 @@ In your mod's `_merge` folder, look for any `json` files and rewrite their conte
 ]
 ```
 
-More information about this new system can be found at [Merging Files](10-appending-and-merging-files/10-02-merging-files.md).
+More information about this new system can be found at [Merging Files](../10-appending-and-merging-files/10-02-merging-files.md).
 
 ## Removal of Flixel UI
 


### PR DESCRIPTION
The `Merging Files` link would redirect to an incorrect page inside of Modding Docs. This pull request aims to fix this small oversight.