### PR TITLE
[BUGFIX?] Fix Bad Links

### DIFF
--- a/src/02-custom-songs-and-custom-levels/02-05-adding-variations-to-existing-songs.md
+++ b/src/02-custom-songs-and-custom-levels/02-05-adding-variations-to-existing-songs.md
@@ -72,10 +72,10 @@ Then we apply a simple patch, which adds a new value to the `playData.songVariat
 ]
 ```
 
-The patching system is very flexible; it works on any JSON file (base game or provided by another mod) and has support for advanced behavior. See [Merging Files](10-appending-and-merging-files/10-02-merging-files.md) for more information.
+The patching system is very flexible; it works on any JSON file (base game or provided by another mod) and has support for advanced behavior. See [Merging Files](../10-appending-and-merging-files/10-02-merging-files.md) for more information.
 
 ## Conclusion
 
 Now, when you start the game, your additional variation should be available in-game!
 
-If you created a character remix, make sure the player character for the remix is included in the `ownedCharacters` data for your custom playable character. See [Custom Playable Characters](05-custom-playable-characters/05-00-custom-playable-characters.md) for more info.
+If you created a character remix, make sure the player character for the remix is included in the `ownedCharacters` data for your custom playable character. See [Custom Playable Characters](../05-custom-playable-characters/05-00-custom-playable-characters.md) for more info.

--- a/src/03-custom-characters/03-00-custom-characters.md
+++ b/src/03-custom-characters/03-00-custom-characters.md
@@ -2,4 +2,4 @@
 
 This chapter will walk you through the process of creating a functioning, fully compatible Friday Night Funkin' mod, using the game's official systems for loading custom content and scripts. Once your mod is complete, you will be able to place it in the `mods` folder in your game install and use its content in-game without overriding the base game content and still maintain compatibility with other mods.
 
-This chapter goes over adding new characters to the game, and using them in a level. If you are looking for adding characters to the character select screen, see [Custom Playable Characters](05-custom-playable-characters/05-00-custom-playable-characters.md).
+This chapter goes over adding new characters to the game, and using them in a level. If you are looking for adding characters to the character select screen, see [Custom Playable Characters](../05-custom-playable-characters/05-00-custom-playable-characters.md).

--- a/src/05-custom-playable-characters/05-01-required-assets.md
+++ b/src/05-custom-playable-characters/05-01-required-assets.md
@@ -2,9 +2,9 @@
 
 In order to make a fleshed out custom character that can be used from Character Select in Friday Night Funkin', you need a large number of textures, animations, and audio tracks:
 
-- A [custom character](03-custom-characters/03-00-custom-characters.md)
+- A [custom character](../03-custom-characters/03-00-custom-characters.md)
     - This requires a set of singing animations for the character.
-- At least one custom song that uses that character; this can be either [a new song](02-custom-songs-and-custom-levels/02-02-adding-the-custom-song.md) or a [variation added to an existing song](02-custom-songs-and-custom-levels/02-05-adding-variations-to-existing-songs.md).
+- At least one custom song that uses that character; this can be either [a new song](../02-custom-songs-and-custom-levels/02-02-adding-the-custom-song.md) or a [variation added to an existing song](../02-custom-songs-and-custom-levels/02-05-adding-variations-to-existing-songs.md).
     - This requires an instrumental and split vocal tracks.
 - A pixel icon asset to use for that character's icon in the Character Select grid.
     - This supports either a static image or a Sparrow spritesheet (which includes the animation to play when the character is selected).

--- a/src/05-custom-playable-characters/05-02-creating-a-playable-character.md
+++ b/src/05-custom-playable-characters/05-02-creating-a-playable-character.md
@@ -160,7 +160,7 @@ A custom playable character requires creating a new JSON file in the `data/chara
 The available fields are:
 - `version`: The version number for the Playable Character data file format. Leave this at `1.0.0`.
 - `name`: The readable name for the character, used internally.
-- `ownedCharacters`: The list of [Characters](03-custom-characters/03-00-custom-characters.md) this character owns.
+- `ownedCharacters`: The list of [Characters](../03-custom-characters/03-00-custom-characters.md) this character owns.
     - When determining which songs to display in Freeplay, the game checks for any songs where the player character is in this list and displays those. Songs where the player character is in another array are not displayed.
 - `showUnownedChars`: If this value is `true`, then songs whose player character is not in any `ownedCharacters` list will be displayed for this character.
 - `unlocked`: Whether the character is unlocked.


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/funkin-modding-docs/issues/28
## Description
This PR fixes bad links which lead you to 404 in these categories:
* 2 bad links in "[Adding Variations to Existing Songs](https://funkincrew.github.io/funkin-modding-docs/02-custom-songs-and-custom-levels/02-05-adding-variations-to-existing-songs.html#adding-variations-to-existing-songs)"
* 1 bad link in "[Creating a Friday Night Funkin' Mod - Custom Characters](https://funkincrew.github.io/funkin-modding-docs/03-custom-characters/03-00-custom-characters.html#creating-a-friday-night-funkin-mod---custom-characters)"
* 3 bad links in "[Required Assets](https://funkincrew.github.io/funkin-modding-docs/05-custom-playable-characters/05-01-required-assets.html#required-assets)"
* 1 bad link in "[Creating a Playable Character](https://funkincrew.github.io/funkin-modding-docs/05-custom-playable-characters/05-02-creating-a-playable-character.html#creating-a-playable-character)"