### PR TITLE
[BUGFIX] Fix Summary Leading to Non-existent "Scripted Classes"

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -51,7 +51,7 @@
 
 - [Using HScript](20-using-hscript/20-00-using-hscript.md)
     - [What is HScript?](20-using-hscript/20-01-what-is-hscript.md)
-- [Scripted Classes](20-using-hscript/21-00-scripted-classes.md)
+- [Scripted Classes](21-scripted-classes/21-00-scripted-classes.md)
     - [Scripted Songs](21-scripted-classes/21-01-scripted-songs.md)
 
 # HScript (Advanced)


### PR DESCRIPTION
## Linked Issues
https://github.com/FunkinCrew/funkin-modding-docs/issues/19
## Description
* Before this PR, whenever you tried to click on "Scripted Classes", it would lead you to a blank page that has no written information on it:

![image](https://github.com/user-attachments/assets/5983f8fb-5186-447a-9a48-3b35e73f4f1d)

* Now, with this PR, it will lead to the actual page that finally contains the needed information one might need to using scripting classes (why else would it be written?)